### PR TITLE
Revert update of arviz_example_data artifact to v0.3.0

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,6 +1,6 @@
 [arviz_example_data]
-git-tree-sha1 = "10dfbe816ce1628f5ae460225e082e0eabbe064b"
+git-tree-sha1 = "88acee5c1db592b660a577a21fa9bdc783ec49d7"
 
     [[arviz_example_data.download]]
-    sha256 = "5184099a8b8167e990852f21090dd11592fad79ae400ef04e3710b386a5857aa"
-    url = "https://github.com/arviz-devs/arviz_example_data/archive/refs/tags/v0.3.0.tar.gz"
+    sha256 = "4297b17abbc913bb4cd40ec842a1dc5666a8ccfd28a06d995ed8b11e845e46d3"
+    url = "https://github.com/arviz-devs/arviz_example_data/archive/refs/tags/v0.2.0.tar.gz"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArviZExampleData"
 uuid = "2f96bb34-afd9-46ae-bcd0-9b2d4372fe3c"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.1.11"
+version = "0.1.13"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArviZExampleData"
 uuid = "2f96bb34-afd9-46ae-bcd0-9b2d4372fe3c"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.1.12"
+version = "0.1.11"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"


### PR DESCRIPTION
While it's tricky to define what a breaking change to this package is, since the package is often used in documentation and doctests, any change to the data that isn't marked as breaking can cause many spontaneous downstream doctest failures. This PR reverts the previous update to arviz_example_data v0.3.0. The PR will again be reverted in a breaking release.