### PR TITLE
fix: Use http instead of https in URLs

### DIFF
--- a/src/register.jl
+++ b/src/register.jl
@@ -2,7 +2,8 @@ function register_data(md::LocalFileMetadata)
     return DataDeps.register(DataDeps.ManualDataDep(md.name, md.description))
 end
 function register_data(md::RemoteFileMetadata)
-    return DataDeps.register(DataDeps.DataDep(md.name, md.description, md.url, md.checksum))
+    url = replace(md.url, "https" => "http")
+    return DataDeps.register(DataDeps.DataDep(md.name, md.description, url, md.checksum))
 end
 
 register_all_data() = map(register_data, values(REMOTE_EXAMPLE_DATA))


### PR DESCRIPTION
This is just to test if this is the problem with datasets failing to download on macos runners