### PR TITLE
ci: drop x64 arch pin from CI matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -25,21 +25,16 @@ jobs:
           - 'pre'
         os:
           - ubuntu-latest
-        arch:
-          - x64
         include:
           - version: '1'
             os: windows-latest
-            arch: x64
           - version: '1'
             os: macOS-latest
-            arch: x64
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1


### PR DESCRIPTION
The macOS-latest job is failing because macos-latest now resolves to an arm64-only image, and our matrix pins `arch: x64` (see https://github.com/arviz-devs/ArviZExampleData.jl/actions/runs/27817239308/job/82321392867). arch never actually varied across this matrix, so this just drops it entirely and lets setup-julia pick the right architecture per runner.